### PR TITLE
fix: Move to use loading methods instead of class constructor

### DIFF
--- a/src/anemoi/registry/entry/experiment.py
+++ b/src/anemoi/registry/entry/experiment.py
@@ -268,7 +268,7 @@ class ExperimentCatalogueEntry(CatalogueEntry):
             self.patch([{"op": "add", "path": f"/runs/{run_number}/{key}", "value": value}])
 
     def _add_one_weights(self, path, **kwargs):
-        weights = WeightCatalogueEntry(path=path)
+        weights = WeightCatalogueEntry.load_from_path(path=path)
 
         if not WeightCatalogueEntry.key_exists(weights.key):
             # weights with this uuid does not exist, register and upload them
@@ -279,7 +279,7 @@ class ExperimentCatalogueEntry(CatalogueEntry):
             # Weights with this uuid already exist
             # Skip if the weights are the same
             # Raise an error if the weights are different
-            other = WeightCatalogueEntry(key=weights.key)
+            other = WeightCatalogueEntry.load_from_key(key=weights.key)
             if other.record["metadata"]["timestamp"] == weights.record["metadata"]["timestamp"]:
                 LOG.info(
                     f"Not updating weights with key={weights.key}, because it already exists and has the same timestamp"

--- a/src/anemoi/registry/entry/weights.py
+++ b/src/anemoi/registry/entry/weights.py
@@ -33,7 +33,7 @@ class WeightsCatalogueEntryList(RestItemList):
 
     def __iter__(self):
         for v in self.get():
-            yield WeightCatalogueEntry(key=v["uuid"])
+            yield WeightCatalogueEntry.load_from_key(key=v["uuid"])
 
 
 class WeightCatalogueEntry(CatalogueEntry):


### PR DESCRIPTION
## Description
Move to use loading methods instead of class constructor

## What problem does this change solve?
Fixes bug in creation of `WeightCatalogueEntry` objects.

## What issue or task does this change relate to?
#114 

Tested with a broken prepml finish task and works.

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
